### PR TITLE
revert: remove sync toast from matricula page

### DIFF
--- a/apps/extension/src/entrypoints/matricula.content/UFABC-Matricula.vue
+++ b/apps/extension/src/entrypoints/matricula.content/UFABC-Matricula.vue
@@ -8,10 +8,6 @@ import { useFilters } from "@/composables/useFilters";
 import { useModals } from "@/composables/useModals";
 import { useComponentsBuilder } from "@/composables/useComponentsBuilder";
 import { syncMatriculaStudent, updateStudent, type UpdatedStudent } from "@/services/next";
-import { storage } from "wxt/storage";
-
-const SYNC_TOAST_STORAGE_KEY = "local:lastSessionSyncToastAt";
-const SYNC_TOAST_INTERVAL_MS = 24 * 60 * 60 * 1000;
 
 const matriculas = inject<typeof window.matriculas>("matriculas");
 const sessionId = inject<string>("sessionId");
@@ -57,17 +53,6 @@ const sessionMutation = useMutation({
   },
   onError: (error) => {
     logger.error({ error }, "Failed to sync session");
-    toast.error("Falha ao sincronizar dados da sessão");
-  },
-  onSuccess: async () => {
-    const lastShownAt = await storage.getItem<number>(SYNC_TOAST_STORAGE_KEY);
-    const alreadyShownRecently = lastShownAt && Date.now() - lastShownAt < SYNC_TOAST_INTERVAL_MS;
-    if (alreadyShownRecently) {
-      return;
-    }
-
-    toast.success("Sessão sincronizada com sucesso");
-    await storage.setItem(SYNC_TOAST_STORAGE_KEY, Date.now());
   },
 });
 

--- a/apps/extension/src/entrypoints/matricula.content/index.ts
+++ b/apps/extension/src/entrypoints/matricula.content/index.ts
@@ -7,7 +7,6 @@ import { sendMessage } from "@/messaging";
 import { logger } from "@/utils/logger";
 import type { ContentScriptContext } from "wxt/client";
 import { getStudent } from "@/services/next";
-import { Toaster } from "vue-sonner";
 
 export type UFABCMatriculaStudent = {
   studentId: number;
@@ -22,8 +21,6 @@ export default defineContentScript({
 
     const ui = await mountUFABCMatriculaFilters(ctx, sessionId, login);
     ui.mount();
-
-    mountToaster(ctx).mount();
 
     const $meio = document.querySelector<HTMLDivElement>("#meio");
     const $mountedUi = $meio?.firstChild as unknown as HTMLDivElement;
@@ -91,22 +88,6 @@ async function mountUFABCMatriculaFilters(ctx: ContentScriptContext, sessionId: 
       const resolvedMounted = await mounted;
       resolvedMounted?.app.unmount();
       resolvedMounted?.wrapper.remove();
-    },
-  });
-}
-
-function mountToaster(ctx: ContentScriptContext) {
-  return createIntegratedUi(ctx, {
-    position: "inline",
-    anchor: "body",
-    append: "last",
-    onMount(wrapper) {
-      const app = createApp(Toaster, { position: "top-right" });
-      app.mount(wrapper);
-      return app;
-    },
-    onRemove(app) {
-      app?.unmount();
     },
   });
 }


### PR DESCRIPTION
## Summary
- Removes the session-sync success/error toast added earlier (Toaster mount + 24h-cache plumbing) — doesn't pull its weight for now.
- `logger.error` still logs sync failures, just no longer surfaced as a toast.
- Leaves the pre-existing `toast.warning(...)` call in `changeCursadas()` untouched in source, but note it becomes a silent no-op now that no `<Toaster>` is mounted anywhere on the page — flagging in case that's not intended.