### PR TITLE
fix(core): respect error.statusCode in global error handler

### DIFF
--- a/apps/core/src/plugins/v2/error-handler.ts
+++ b/apps/core/src/plugins/v2/error-handler.ts
@@ -72,16 +72,31 @@ export default fp(
         }
 
         if (error instanceof Error) {
-          request.log.error(
-            { error, request: requestContext },
-            error.message
-          );
+          const statusCode =
+            'statusCode' in error &&
+            typeof error.statusCode === 'number' &&
+            error.statusCode >= 400 &&
+            error.statusCode < 600
+              ? error.statusCode
+              : 500;
 
-          reply.status(500);
+          if (statusCode >= 500) {
+            request.log.error(
+              { error, request: requestContext },
+              error.message
+            );
+          } else {
+            request.log.warn(
+              { error, request: requestContext },
+              error.message
+            );
+          }
+
+          reply.status(statusCode);
           reply.send({
             error: error.name,
             message: error.message,
-            statusCode: 500,
+            statusCode,
           });
           return;
         }


### PR DESCRIPTION
## What was found

During the biggest enrollment-window traffic day this service has seen, Axiom log investigation found that ~19,600 of the day's 38,834 "500 errors" (~50%) were actually `429` rate-limit rejections mislabeled as server errors — both in the HTTP response sent to real clients and in the `level:error` log volume.

## Root cause

`@fastify/rate-limit` throws a plain `Error` with `.statusCode = 429` set on it (confirmed at `node_modules/.pnpm/@fastify+rate-limit@10.3.0/node_modules/@fastify/rate-limit/index.js:32-33`). The global error handler's final fallback branch (`apps/core/src/plugins/v2/error-handler.ts`) matched on `error instanceof Error` and hardcoded `reply.status(500)` plus `statusCode: 500` in the JSON body, ignoring `error.statusCode` entirely. It also always logged at `request.log.error`, regardless of the error's actual severity.

## The fix

In that fallback branch, extract a real status code from the error when present and valid (`'statusCode' in error && typeof error.statusCode === 'number' && error.statusCode >= 400 && error.statusCode < 600`), defaulting to 500 only when absent or invalid. Use the resolved status for `reply.status(...)` and the response body's `statusCode` field. Log at `request.log.error` only when the resolved status is >= 500; log at `request.log.warn` for 4xx, matching the convention already used in the `RequestValidationError` branch above it in the same file.

No other branches in the file were touched.