### PR TITLE
fix(core): trust reverse proxy and wire rate-limit config

### DIFF
--- a/apps/core/src/plugins/external/rate-limit.ts
+++ b/apps/core/src/plugins/external/rate-limit.ts
@@ -1,12 +1,12 @@
 import fastifyRateLimit from '@fastify/rate-limit';
-// import type { FastifyInstance } from 'fastify';
+import type { FastifyInstance } from 'fastify';
 
-// export const autoConfig = (app: FastifyInstance) => {
-//   return {
-//     max: app.config.RATE_LIMIT_MAX,
-//     timeWindow: '1 minute',
-//   };
-// };
+export const autoConfig = (app: FastifyInstance) => {
+  return {
+    max: app.config.RATE_LIMIT_MAX,
+    timeWindow: '1 minute',
+  };
+};
 
 /**
  * This plugins is low overhead rate limiter for your routes.

--- a/apps/core/src/server.ts
+++ b/apps/core/src/server.ts
@@ -13,6 +13,7 @@ const appOptions = {
   requestIdLogLabel: 'globalTraceId',
   genReqId: () => randomUUID(),
   pluginTimeout: 35_000,
+  trustProxy: true,
 } satisfies FastifyServerOptions;
 
 


### PR DESCRIPTION
## Problem

During the 2026-08-31 enrollment spike (258K requests in peak hour), the rate limiter treated ALL real students as a single client because:

1. **No `trustProxy` config** — behind the reverse proxy, `request.ip` resolved to `172.17.0.1` (Docker bridge) for all requests, so `@fastify/rate-limit`'s default IP-keyed limiting lumped every user into one bucket.
2. **`autoConfig` was commented out** — `RATE_LIMIT_MAX` from config was never wired in; the limiter ran on library defaults.

Result: 8,854 false-positive 429 responses, 98% hitting `/v2/students` — real enrolling students blocked during the highest-legitimacy traffic of the day.

## Changes

- **`server.ts`**: Added `trustProxy: true` to Fastify server options so `request.ip` reflects the real client IP via the `X-Forwarded-For` header from the reverse proxy.
- **`rate-limit.ts`**: Uncommented `autoConfig` to wire `RATE_LIMIT_MAX` (from env config, zod default 100) and set `timeWindow: '1 minute'`.

## Impact

After this change, rate limiting will key on actual client IPs instead of the proxy IP, and will use the configured max requests per minute. This eliminates the false-positive 429 blanket that hit during enrollment windows.

Co-authored-by: claude-agent <noreply@anthropic.com>