### PR TITLE
fix: comment 500, error i18n field, and teacher cache leak

### DIFF
--- a/apps/container/src/components/ReviewDialog/ReviewDialog.vue
+++ b/apps/container/src/components/ReviewDialog/ReviewDialog.vue
@@ -84,8 +84,9 @@
 
 <script setup lang="ts">
 import { useMutation, useQuery, useQueryClient } from '@tanstack/vue-query';
-import type { Enrollment } from '@next/services';
+import type { Enrollment, RequestError } from '@next/services';
 import { Comments, Enrollments } from '@next/services';
+import { AxiosError } from 'axios';
 import { ElMessage } from 'element-plus';
 import { computed, PropType, ref, watch } from 'vue';
 
@@ -217,9 +218,12 @@ const { mutate: mutateCreate, isPending: isCreatingComment } = useMutation({
       showClose: true,
     });
   },
-  onError: () => {
+  onError: (error: AxiosError<RequestError>) => {
     ElMessage({
-      message: 'Ocorreu um erro ao enviar o comentário',
+      message:
+        error.response?.data.translatedDescription ??
+        error.response?.data.message ??
+        'Ocorreu um erro ao enviar o comentário',
       type: 'error',
       showClose: true,
     });
@@ -248,9 +252,12 @@ const { mutate: mutateUpdate, isPending: isUpdatingComment } = useMutation({
       showClose: true,
     });
   },
-  onError: () => {
+  onError: (error: AxiosError<RequestError>) => {
     ElMessage({
-      message: 'Ocorreu um erro ao editar o comentário',
+      message:
+        error.response?.data.translatedDescription ??
+        error.response?.data.message ??
+        'Ocorreu um erro ao editar o comentário',
       type: 'error',
       showClose: true,
     });

--- a/apps/core/src/constants.ts
+++ b/apps/core/src/constants.ts
@@ -41,6 +41,7 @@ export const MAX_LOG_SIZE = 600 * 1024;
 export const BYTES_PER_MB = 1024 * 1024;
 export const NANOSECONDS_PER_MS = 1_000_000;
 export const SNAPSHOT_URL_TTL_SECONDS = 7 * 24 * 60 * 60;
+export const TEACHER_CACHE_MAX_SIZE = 500;
 
 export const PARSER_WEBHOOK_EVENTS = {
   CLASS_SETTLED: 'class.settled',

--- a/apps/core/src/errors/base-error.ts
+++ b/apps/core/src/errors/base-error.ts
@@ -6,6 +6,7 @@ export const errorJsonSchema = z.object({
   description: z.string(),
   httpStatus: z.number(),
   title: z.string(),
+  translatedDescription: z.string(),
 });
 
 export const errorHttpSchema = z.object({
@@ -14,6 +15,7 @@ export const errorHttpSchema = z.object({
   description: z.string(),
   statusCode: z.number(),
   title: z.string(),
+  translatedDescription: z.string(),
 });
 
 export type ErrorJson = z.infer<typeof errorJsonSchema>;
@@ -24,6 +26,8 @@ export class NextError extends Error {
   readonly code: string;
   readonly httpStatus: number;
   description: string;
+  /** User-facing translation of `description`, for clients to display directly. */
+  translatedDescription: string;
   additionalData: Record<string, unknown> | null | undefined;
 
   get status(): number {
@@ -39,12 +43,14 @@ export class NextError extends Error {
     code: string,
     httpStatus: number,
     description: string,
+    translatedDescription: string,
     additionalData?: Record<string, unknown> | null
   ) {
     super(title);
     this.name = 'NextError';
     this.title = title;
     this.description = description;
+    this.translatedDescription = translatedDescription;
     this.code = code;
     this.httpStatus = httpStatus;
     this.additionalData = additionalData ?? null;
@@ -57,6 +63,7 @@ export class NextError extends Error {
       description: this.description,
       httpStatus: this.httpStatus,
       title: this.title,
+      translatedDescription: this.translatedDescription,
     };
 
     return errorJsonSchema.parse(json);
@@ -69,6 +76,7 @@ export class NextError extends Error {
       description: this.description,
       statusCode: this.httpStatus,
       title: this.title,
+      translatedDescription: this.translatedDescription,
     };
 
     return errorHttpSchema.parse(http);

--- a/apps/core/src/errors/custom-errors.ts
+++ b/apps/core/src/errors/custom-errors.ts
@@ -1,8 +1,17 @@
 import { NextError } from './base-error.js';
 
 export class EmailVerificationFailed extends NextError {
-  constructor(description = 'Unable to verify user email') {
-    super('Email Verification Failed', 'NEX0001', 400, description);
+  constructor(
+    description = 'Unable to verify user email',
+    translatedDescription = 'Não foi possível verificar o e-mail do usuário'
+  ) {
+    super(
+      'Email Verification Failed',
+      'NEX0001',
+      400,
+      description,
+      translatedDescription
+    );
   }
 }
 
@@ -12,14 +21,21 @@ export class UserWithoutRA extends NextError {
       'User Without RA',
       'NEX0002',
       403,
-      'User does not have an RA registered'
+      'User does not have an RA registered',
+      'Usuário não possui um RA cadastrado'
     );
   }
 }
 
 export class ArchiveParseFailed extends NextError {
   constructor(description: string) {
-    super('Archive Parse Failed', 'NEX0003', 400, description);
+    super(
+      'Archive Parse Failed',
+      'NEX0003',
+      400,
+      description,
+      'Não foi possível processar o arquivo enviado'
+    );
   }
 }
 
@@ -29,13 +45,32 @@ export class ArchiveNotFound extends NextError {
       'Archive Not Found',
       'NEX0004',
       404,
-      'Archive not found or not yet stored'
+      'Archive not found or not yet stored',
+      'Arquivo não encontrado ou ainda não armazenado'
     );
   }
 }
 
 export class ArchiveFileEmpty extends NextError {
   constructor() {
-    super('Archive File Empty', 'NEX0005', 500, 'Empty file on S3');
+    super(
+      'Archive File Empty',
+      'NEX0005',
+      500,
+      'Empty file on S3',
+      'O arquivo enviado está vazio'
+    );
+  }
+}
+
+export class DuplicateComment extends NextError {
+  constructor(enrollment: string) {
+    super(
+      'Duplicate Comment',
+      'NEX0006',
+      409,
+      `You can only comment once on enrollment ${enrollment}`,
+      `Você só pode comentar uma vez neste vínculo ${enrollment}`
+    );
   }
 }

--- a/apps/core/src/errors/custom-errors.ts
+++ b/apps/core/src/errors/custom-errors.ts
@@ -1,3 +1,5 @@
+import type { Types } from 'mongoose';
+
 import { NextError } from './base-error.js';
 
 export class EmailVerificationFailed extends NextError {
@@ -64,13 +66,14 @@ export class ArchiveFileEmpty extends NextError {
 }
 
 export class DuplicateComment extends NextError {
-  constructor(enrollment: string) {
+  constructor(enrollment: Types.ObjectId) {
     super(
       'Duplicate Comment',
       'NEX0006',
       409,
-      `You can only comment once on enrollment ${enrollment}`,
-      `Você só pode comentar uma vez neste vínculo ${enrollment}`
+      'User already has a comment on this enrollment',
+      'Você já possui um comentário neste vínculo',
+      { enrollment }
     );
   }
 }

--- a/apps/core/src/models/Comment.ts
+++ b/apps/core/src/models/Comment.ts
@@ -151,7 +151,7 @@ commentSchema.pre('save', async function () {
       type: this.type,
     });
     if (enrollment) {
-      throw new DuplicateComment(String(this.enrollment));
+      throw new DuplicateComment(this.enrollment);
     }
   }
 });

--- a/apps/core/src/models/Comment.ts
+++ b/apps/core/src/models/Comment.ts
@@ -8,6 +8,8 @@ import {
   model,
 } from 'mongoose';
 
+import { DuplicateComment } from '@/errors/custom-errors.js';
+
 import { EnrollmentModel } from './Enrollment.js';
 import { ReactionModel } from './Reaction.js';
 
@@ -149,9 +151,7 @@ commentSchema.pre('save', async function () {
       type: this.type,
     });
     if (enrollment) {
-      throw new Error(
-        `Você só pode comentar uma vez neste vinculo ${this.enrollment}`
-      );
+      throw new DuplicateComment(String(this.enrollment));
     }
   }
 });

--- a/apps/core/src/models/Teacher.ts
+++ b/apps/core/src/models/Teacher.ts
@@ -98,6 +98,28 @@ teacherSchema.index(
   { unique: true, name: 'TeacherExternalKeyIndex', sparse: true }
 );
 
+const TEACHER_CACHE_MAX_SIZE = 500;
+
+/**
+ * Sets a cache entry, evicting the oldest entry first if `cache` is already
+ * at `maxSize` — without this, `teacherCache` below grows unbounded for the
+ * life of the process (it caches every distinct teacher name variant ever seen).
+ */
+export function setTeacherCacheEntry<Value>(
+  cache: Map<string, Value>,
+  key: string,
+  value: Value,
+  maxSize = TEACHER_CACHE_MAX_SIZE
+) {
+  if (cache.size >= maxSize && !cache.has(key)) {
+    const oldestKey = cache.keys().next().value;
+    if (oldestKey !== undefined) {
+      cache.delete(oldestKey);
+    }
+  }
+  cache.set(key, value);
+}
+
 const teacherCache = new Map<string, Types.ObjectId | null>();
 
 export async function findTeacher(
@@ -120,13 +142,13 @@ export async function findTeacher(
       await TeacherModel.findByIdAndUpdate(levMatch._id, {
         $addToSet: { alias: { $each: [normalizedName, name.toLowerCase()] } },
       });
-      teacherCache.set(normalizedName, levMatch._id);
+      setTeacherCacheEntry(teacherCache, normalizedName, levMatch._id);
       return levMatch._id;
     }
   }
 
   if (!teacher && normalizedName !== '0') {
-    teacherCache.set(normalizedName, null);
+    setTeacherCacheEntry(teacherCache, normalizedName, null);
     return null;
   }
 
@@ -137,7 +159,7 @@ export async function findTeacher(
   }
 
   const teacherId = teacher?._id ?? null;
-  teacherCache.set(normalizedName, teacherId);
+  setTeacherCacheEntry(teacherCache, normalizedName, teacherId);
   return teacherId;
 }
 

--- a/apps/core/src/models/Teacher.ts
+++ b/apps/core/src/models/Teacher.ts
@@ -1,5 +1,7 @@
 import { type InferSchemaType, Schema, model, Types } from 'mongoose';
 
+import { TEACHER_CACHE_MAX_SIZE } from '@/constants.js';
+
 export function normalizeName(str: string): string {
   return str
     .toLowerCase()
@@ -97,8 +99,6 @@ teacherSchema.index(
   { externalKey: 1 },
   { unique: true, name: 'TeacherExternalKeyIndex', sparse: true }
 );
-
-const TEACHER_CACHE_MAX_SIZE = 500;
 
 /**
  * Sets a cache entry, evicting the oldest entry first if `cache` is already

--- a/apps/core/src/plugins/v2/error-handler.ts
+++ b/apps/core/src/plugins/v2/error-handler.ts
@@ -67,7 +67,11 @@ export default fp(
 
           const httpBody = error.toHttp();
           reply.status(httpBody.statusCode);
-          reply.send(httpBody);
+          reply.send({
+            ...httpBody,
+            error: httpBody.title,
+            message: httpBody.description,
+          });
           return;
         }
 

--- a/apps/core/tests/unit/teacher-cache.spec.ts
+++ b/apps/core/tests/unit/teacher-cache.spec.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+import { setTeacherCacheEntry } from '../../src/models/Teacher.js';
+
+describe('setTeacherCacheEntry', () => {
+  it('evicts the oldest entry once maxSize is reached', () => {
+    const cache = new Map<string, string | null>();
+
+    setTeacherCacheEntry(cache, 'a', 'teacher-a', 2);
+    setTeacherCacheEntry(cache, 'b', 'teacher-b', 2);
+    setTeacherCacheEntry(cache, 'c', 'teacher-c', 2);
+
+    expect(cache.size).toBe(2);
+    expect(cache.has('a')).toBe(false);
+    expect(cache.get('b')).toBe('teacher-b');
+    expect(cache.get('c')).toBe('teacher-c');
+  });
+
+  it('does not evict when updating an existing key at capacity', () => {
+    const cache = new Map<string, string | null>();
+
+    setTeacherCacheEntry(cache, 'a', 'teacher-a', 2);
+    setTeacherCacheEntry(cache, 'b', 'teacher-b', 2);
+    setTeacherCacheEntry(cache, 'a', 'teacher-a-updated', 2);
+
+    expect(cache.size).toBe(2);
+    expect(cache.get('a')).toBe('teacher-a-updated');
+    expect(cache.get('b')).toBe('teacher-b');
+  });
+});

--- a/packages/services/src/types/index.ts
+++ b/packages/services/src/types/index.ts
@@ -121,6 +121,8 @@ export type RequestError = {
   type: string;
   error: string;
   message: string;
+  /** User-facing translation of `message`/`description`, safe to render directly. */
+  translatedDescription?: string;
 };
 
 export type SearchTeacherItem = {

--- a/packages/services/src/types/request-error.ts
+++ b/packages/services/src/types/request-error.ts
@@ -1,7 +1,0 @@
-export type RequestError = {
-  status: number;
-  name: string;
-  type: string;
-  error: string;
-  message: string;
-};


### PR DESCRIPTION
## Comment creation returned 500 instead of 409

`Comment.ts`'s pre-save hook threw a plain `Error` on a duplicate comment, which `error-handler.ts` defaults to 500 since it has no `statusCode`:

```
 commentSchema.pre('save', ...)
   if (duplicate found)
-    throw new Error('Você só pode comentar...')   // no statusCode → defaults to 500
+    throw new DuplicateComment(enrollment)         // NextError, httpStatus 409
```

## NextError responses were unreadable by the frontend

Every frontend `onError` handler reads `error.response.data.{error,message}` — but `NextError.toHttp()` sends `{title, description}`. So **no** `NextError` subclass (`EmailVerificationFailed`, `UserWithoutRA`, `ArchiveNotFound`, ...) has ever surfaced its message to a user, not just the new `DuplicateComment` one. Fixed once, in the shared handler:

```
 if (error instanceof NextError) {
   const httpBody = error.toHttp();
   reply.status(httpBody.statusCode);
-  reply.send(httpBody);
+  reply.send({ ...httpBody, error: httpBody.title, message: httpBody.description });
 }
```

`ReviewDialog.vue`'s comment create/update handlers now render that message instead of a hardcoded generic string.

## Backend errors stay English, frontend gets a translated field

`NextError` now carries a separate `translatedDescription`, so `description`/`message` remain agnostic (English, for logs) while clients render the localized copy:

```ts
export class DuplicateComment extends NextError {
  constructor(enrollment: string) {
    super(
      'Duplicate Comment', 'NEX0006', 409,
      `You can only comment once on enrollment ${enrollment}`,       // description (English)
      `Você só pode comentar uma vez neste vínculo ${enrollment}`,   // translatedDescription
    );
  }
}
```

All existing `NextError` subclasses got a `translatedDescription`. `RequestError` (in `@next/services`) gained the matching optional field.

Also deleted `packages/services/src/types/request-error.ts` — a dead, unexported duplicate of the real `RequestError` type in `types/index.ts` found while wiring this up.

## Teacher cache grew unbounded for the process lifetime

`apps/core/src/models/Teacher.ts`'s module-level `teacherCache` had no eviction — every distinct teacher-name variant ever seen stayed cached until process restart (its `clearTeacherCache()` cleanup existed but was never called). Added bounded LRU-style eviction on insert:

```ts
export function setTeacherCacheEntry<Value>(cache, key, value, maxSize = 500) {
  if (cache.size >= maxSize && !cache.has(key)) {
    cache.delete(cache.keys().next().value);
  }
  cache.set(key, value);
}
```

Covered by `apps/core/tests/unit/teacher-cache.spec.ts`.