### PR TITLE
fix: prevent duplicate cursos entries on repeated student syncs

### DIFF
--- a/apps/core/src/jobs/student-sync-processing.ts
+++ b/apps/core/src/jobs/student-sync-processing.ts
@@ -234,14 +234,34 @@ async function upsertStudentRecord(
     ca: coefficients.ca,
   };
 
-  await StudentModel.updateOne(
-    { ra: Number(ra), season },
+  const updateResult = await StudentModel.updateOne(
+    {
+      ra: Number(ra),
+      season,
+      'cursos.nome_curso': courseData.nome_curso,
+      'cursos.turno': courseData.turno,
+    },
     {
       login,
-      $push: { cursos: courseData },
-    },
-    { upsert: true }
+      $set: {
+        'cursos.$.cp': courseData.cp,
+        'cursos.$.cr': courseData.cr,
+        'cursos.$.ca': courseData.ca,
+        'cursos.$.ind_afinidade': courseData.ind_afinidade,
+      },
+    }
   );
+
+  if (updateResult.matchedCount === 0) {
+    await StudentModel.updateOne(
+      { ra: Number(ra), season },
+      {
+        login,
+        $push: { cursos: courseData },
+      },
+      { upsert: true }
+    );
+  }
 }
 
 async function createHistoryRecord(


### PR DESCRIPTION
## Problem

Every `student.synced` webhook unconditionally `$push`ed a new `cursos` entry, so re-syncing the same student/season kept appending duplicates instead of updating the existing course record:

```
on(student.synced)
  $push cursos entry        # always appends, never checks for existing match
```

With N syncs for the same course in a season, `cursos` grows to N near-identical entries (seen in prod: 6 duplicate entries for one RA/season).

## Fix

`upsertStudentRecord` now updates the matching entry in place, falling back to push only when there's no match:

```
on(student.synced)
  if cursos entry matches (ra, season, nome_curso, turno)
    $set that entry's cp/cr/ca/ind_afinidade
  else
    $push new cursos entry
```

`apps/core/src/jobs/student-sync-processing.ts`