### PR TITLE
fix(core): stop 500ing on expected reaction validation failures

### DIFF
--- a/apps/core/src/errors/custom-errors.ts
+++ b/apps/core/src/errors/custom-errors.ts
@@ -77,3 +77,29 @@ export class DuplicateComment extends NextError {
     );
   }
 }
+
+export class DuplicateReaction extends NextError {
+  constructor(comment: Types.ObjectId, user: Types.ObjectId, kind: string) {
+    super(
+      'Duplicate Reaction',
+      'NEX0007',
+      409,
+      'User already reacted to this comment with this reaction kind',
+      'Você não pode reagir duas vezes iguais ao mesmo comentário',
+      { comment, user, kind }
+    );
+  }
+}
+
+export class RecommendationNotAllowed extends NextError {
+  constructor(comment: Types.ObjectId, user: Types.ObjectId) {
+    super(
+      'Recommendation Not Allowed',
+      'NEX0008',
+      403,
+      'User cannot recommend a comment for a teacher they have not taken',
+      'Você não pode recomendar este comentário, pois não fez nenhuma matéria com este professor',
+      { comment, user }
+    );
+  }
+}

--- a/apps/core/src/models/Reaction.ts
+++ b/apps/core/src/models/Reaction.ts
@@ -5,6 +5,11 @@ import {
   model,
 } from 'mongoose';
 
+import {
+  DuplicateReaction,
+  RecommendationNotAllowed,
+} from '@/errors/custom-errors.js';
+
 import { CommentModel } from './Comment.js';
 import { EnrollmentModel } from './Enrollment.js';
 import { UserModel } from './User.js';
@@ -62,9 +67,7 @@ async function validateRules(reaction: ReactionDocument) {
     });
 
     if (!isValid)
-      throw new Error(
-        'Você não pode recomendar este comentário, pois não fez nenhuma matéria com este professor'
-      );
+      throw new RecommendationNotAllowed(reaction.comment, reaction.user);
   }
 }
 
@@ -93,9 +96,7 @@ reactionSchema.pre('save', async function () {
   if (this.isNew) {
     const equalReaction = await this.collection.findOne({ slug });
     if (equalReaction) {
-      throw new Error(
-        'Você não pode reagir duas vezes iguais ao mesmo comentário'
-      );
+      throw new DuplicateReaction(this.comment, this.user, this.kind);
     }
     this.slug = slug;
   }


### PR DESCRIPTION
Same anti-pattern as the comments 500 fixed earlier — `Reaction.ts` threw plain `Error`s for two expected validation failures, both defaulting to 500 in `error-handler.ts` since neither had a `statusCode`.

```
 reactionSchema.pre('save', ...)
   if (duplicate reaction found)
-    throw new Error('Você não pode reagir duas vezes...')       // no statusCode → 500
+    throw new DuplicateReaction(comment, user, kind)              // NextError, 409

 validateRules(reaction)
   if (recommending a teacher not taken)
-    throw new Error('Você não pode recomendar...')               // no statusCode → 500
+    throw new RecommendationNotAllowed(comment, user)             // NextError, 403
```

Confirmed live in Axiom: `POST /comments/reactions/:id` hit the duplicate-reaction 500 five times over the past week.

IDs go into `additionalData` rather than getting stringified into the message, matching the `DuplicateComment` fix.