### PR TITLE
fix(container): stop 500ing Google account linking from Settings

### DIFF
--- a/apps/container/src/utils/runtimeConfig.test.ts
+++ b/apps/container/src/utils/runtimeConfig.test.ts
@@ -43,8 +43,10 @@ describe('runtimeConfig', () => {
   });
 
   test('builds google account association url', () => {
-    expect(buildGoogleAuthUrl({ userId: 'user-123' })).toBe(
-      `${runtimeConfig.apiBaseUrl}/login/google?userId=user-123`,
+    expect(
+      buildGoogleAuthUrl({ requesterKey: 'ufabc-next', userId: 'user-123' }),
+    ).toBe(
+      `${runtimeConfig.apiBaseUrl}/login/google?requesterKey=ufabc-next&userId=user-123`,
     );
   });
 });

--- a/apps/container/src/utils/runtimeConfig.ts
+++ b/apps/container/src/utils/runtimeConfig.ts
@@ -5,7 +5,7 @@ type RequiredEnvKey =
   | 'VITE_PARSER_API_BASE_URL';
 
 type GoogleAuthUrlOptions = {
-  requesterKey?: string;
+  requesterKey: string;
   userId?: string;
   appHostname?: string;
   apiBaseUrl?: string;
@@ -47,12 +47,10 @@ export const buildGoogleAuthUrl = ({
   userId,
   appHostname = window.location.hostname,
   apiBaseUrl = runtimeConfig.apiBaseUrl,
-}: GoogleAuthUrlOptions = {}) => {
+}: GoogleAuthUrlOptions) => {
   const url = new URL('login/google', normalizeBaseUrl(apiBaseUrl));
 
-  if (requesterKey) {
-    url.searchParams.set('requesterKey', requesterKey);
-  }
+  url.searchParams.set('requesterKey', requesterKey);
 
   if (userId) {
     url.searchParams.set('userId', userId);

--- a/apps/container/src/views/Settings/SettingsView.vue
+++ b/apps/container/src/views/Settings/SettingsView.vue
@@ -161,7 +161,7 @@ const userLogin = computed(() => {
 });
 
 const addGoogleAccount = computed(() => {
-  return buildGoogleAuthUrl({ userId: user.value?._id });
+  return buildGoogleAuthUrl({ requesterKey: 'ufabc-next', userId: user.value?._id });
 });
 
 const createdAt = computed(() => {


### PR DESCRIPTION
`SettingsView.vue`'s "link Google account" button was guaranteed to fail:

```
 const addGoogleAccount = computed(() => {
-  return buildGoogleAuthUrl({ userId: user.value?._id });
+  return buildGoogleAuthUrl({ requesterKey: 'ufabc-next', userId: user.value?._id });
 });
```

`buildGoogleAuthUrl` only set `requesterKey` on the URL if it was passed — omitting it entirely otherwise, rather than defaulting or failing. `oauth2.ts`'s `checkStateFunction` requires `requesterKey` to be `'ufabc-next'` or `'ufabc-cronos'`, so every click on this button produced a state payload with `requesterKey: null`, which always throws `Invalid requester key` on the callback → 500. Confirmed live in Axiom: a real student retried this exact flow 4-5 times in under a minute, failing every time.

`LoginView.vue`'s main login button was already correct (`requesterKey: 'ufabc-next'` hardcoded) — only the Settings entry point was missing it.

## Hardening the shared helper

```
 type GoogleAuthUrlOptions = {
-  requesterKey?: string;
+  requesterKey: string;
   ...
 };
 ...
-  if (requesterKey) {
-    url.searchParams.set('requesterKey', requesterKey);
-  }
+  url.searchParams.set('requesterKey', requesterKey);
```

Made `requesterKey` required so a missing value is a compile-time TypeScript error instead of a silently-broken URL — no future caller can reproduce this bug. Updated `runtimeConfig.test.ts`'s "builds google account association url" test, which was asserting the old (buggy) URL shape.