### PR TITLE
Feat/sync ra

### DIFF
--- a/apps/core/src/app.ts
+++ b/apps/core/src/app.ts
@@ -15,6 +15,7 @@ import { proxyController } from './controllers/proxy-controller.js';
 import studentsController from './controllers/students-controller.js';
 import { UfabcParserIncomingWebhookController } from './controllers/ufabc-parser-webhook-controller.js';
 import { authenticateBoard } from './hooks/board-authenticate.js';
+import { ensureUserRaIndex } from './models/User.js';
 import awsV2Plugin from './plugins/v2/aws.js';
 import errorHandlerPlugin from './plugins/v2/error-handler.js';
 import memoryMonitorPlugin from './plugins/v2/memory-monitor.js';
@@ -55,6 +56,7 @@ export async function buildApp(
 
   await app.register(redisV2Plugin);
   await app.register(dbPlugin, { config: app.config });
+  await ensureUserRaIndex();
 
   if (process.env.NEXT_JOBS_ENABLED !== 'false') {
     await app.register(queueV2Plugin, {

--- a/apps/core/src/controllers/students-controller.ts
+++ b/apps/core/src/controllers/students-controller.ts
@@ -2,13 +2,11 @@ import { currentQuad } from '@next/utils';
 import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod';
 import { z } from 'zod';
 
-import { UfabcParserConnector } from '@/connectors/ufabc-parser.js';
 import { matriculaSession } from '@/hooks/matricula-session.js';
 import { sigaaSession } from '@/hooks/sigaa-session.js';
 import { StudentModel } from '@/models/Student.js';
 import { findRaByLogin } from '@/utils/resolve-student-ra.js';
-
-const CACHE_TTL = 1000 * 60 * 60 * 24; // 1 day
+import { syncStudentFromSigaa } from '@/services/sigaa-student-sync.js';
 
 export const studentsController: FastifyPluginAsyncZod = async (app) => {
   app.route({
@@ -26,6 +24,7 @@ export const studentsController: FastifyPluginAsyncZod = async (app) => {
         {
           ra,
           season,
+          active: { $ne: false },
         },
         {
           $set: {
@@ -63,6 +62,7 @@ export const studentsController: FastifyPluginAsyncZod = async (app) => {
       const [student] = await StudentModel.find({
         login: request.headers.login,
         season,
+        active: { $ne: false },
       });
 
       if (!student) {
@@ -118,70 +118,46 @@ export const studentsController: FastifyPluginAsyncZod = async (app) => {
 
   app.route({
     handler: async (request, reply) => {
-      const connector = new UfabcParserConnector(request.id);
       const { ra, login } = request.body;
       const { sessionId, viewId } = request.sigaaSession;
-      const cacheKey = `http:students:sigaa:${ra}`;
 
-      const cached = await app.redis.get(cacheKey);
-      if (cached) {
-        app.log.debug({ cacheKey }, 'Student already synced');
-        return await reply.status(202).send({
-          status: 'cached',
-        });
+      const result = await syncStudentFromSigaa(
+        app,
+        { ra, login },
+        { sessionId, viewId },
+        request.id
+      );
+
+      if (result.status === 'not_found') {
+        return reply.notFound(result.message);
       }
 
-      let studentSync = await app.db.StudentSync.findOne({ ra: String(ra) });
-      if (!studentSync) {
-        studentSync = await app.db.StudentSync.create({
-          ra: String(ra),
-          status: 'created',
-          timeline: [
-            {
-              metadata: {
-                login,
-              },
-              status: 'created',
-            },
-          ],
-        });
+      if (result.status === 'cached') {
+        app.log.debug({ cacheKey: result.cacheKey }, 'Student already synced');
+        return reply.status(202).send({ status: 'cached' });
       }
 
-      await connector.syncStudent({
-        requesterKey: app.config.UFABC_PARSER_REQUESTER_KEY,
-        sessionId,
-        viewId,
-      });
-
-      await studentSync.transition('awaiting', {
-        login,
-        source: 'sigaa',
-      });
-      await app.redis.set(cacheKey, login, 'PX', CACHE_TTL);
-
-      return await reply.status(202).send({
-        status: 'success',
-      });
+      return reply.status(202).send(result);
     },
     method: 'POST',
-    preHandler: [sigaaSession],
+    url: '/students/sigaa',
     schema: {
-      body: z.object({
-        login: z.string(),
-        ra: z.number(),
-      }),
       headers: z.object({
         'session-id': z.string(),
         'view-id': z.string(),
       }),
+      body: z.object({
+        ra: z.number(),
+        login: z.string(),
+      }),
       response: {
         202: z.object({
-          data: z.any(),
           status: z.string(),
+          data: z.any(),
         }),
       },
     },
-    url: '/students/sigaa',
+    preHandler: [sigaaSession],
   });
 };
 

--- a/apps/core/src/jobs/student-sync-processing.ts
+++ b/apps/core/src/jobs/student-sync-processing.ts
@@ -211,6 +211,7 @@ async function upsertStudentRecord(
   await StudentModel.updateOne(
     { ra: Number(ra), season },
     {
+      $set: { active: true },
       login: ra,
       $push: { cursos: courseData },
     },
@@ -238,6 +239,7 @@ async function createHistoryRecord(
   const baseUpdate = {
     $set: {
       ra: Number(ra),
+      active: true,
       curso: student.course.toLowerCase(),
       grade: student.campus,
       disciplinas: components.map(transformComponentToHistory),

--- a/apps/core/src/jobs/utils/enrollment-upsert.ts
+++ b/apps/core/src/jobs/utils/enrollment-upsert.ts
@@ -19,6 +19,7 @@ export async function upsertEnrollment(
 ): Promise<string | null> {
   // @ts-ignore - Mongoose FilterQuery type
   const base: FilterQuery<Enrollment> = {
+    active: { $ne: false },
     ra: enrollmentData.ra,
     season: enrollmentData.season,
   };

--- a/apps/core/src/models/Enrollment.ts
+++ b/apps/core/src/models/Enrollment.ts
@@ -18,6 +18,10 @@ const enrollmentSchema = new Schema(
       type: Number,
       required: true,
     },
+    active: {
+      type: Boolean,
+      default: true,
+    },
     disciplina: {
       type: String,
       required: true,

--- a/apps/core/src/models/GraduationHistory.ts
+++ b/apps/core/src/models/GraduationHistory.ts
@@ -26,6 +26,7 @@ type GraduationHistory = {
   curso: string;
   grade: string;
   graduation: Types.ObjectId;
+  active?: boolean;
   coefficients: Record<number, CoefficientsMap>;
 };
 
@@ -67,6 +68,7 @@ const graduationHistorySchema = new Schema<
       type: Number,
       required: true,
     },
+    active: { type: Boolean, default: true },
     coefficients: Object,
 
     disciplinas: [GraduationHistoryDisciplinasSchema],

--- a/apps/core/src/models/History.ts
+++ b/apps/core/src/models/History.ts
@@ -84,6 +84,7 @@ const historiesDisciplinasSchema = new Schema(
 export type History = {
   ra: number;
   disciplinas: InferSchemaType<typeof historiesDisciplinasSchema>[];
+  active?: boolean;
   coefficients: HistoryCoefficients;
   curso: string;
   grade: string | undefined;
@@ -94,6 +95,7 @@ export type HistoryDocument = ReturnType<(typeof HistoryModel)['hydrate']>;
 const historySchema = new Schema<History, THistoryModel>(
   {
     ra: { type: Number, required: true },
+    active: { type: Boolean, default: true },
     disciplinas: [historiesDisciplinasSchema],
     coefficients: Object,
     curso: { type: String, required: true },

--- a/apps/core/src/models/Reaction.ts
+++ b/apps/core/src/models/Reaction.ts
@@ -57,6 +57,7 @@ async function validateRules(reaction: ReactionDocument) {
     const isValid = await EnrollmentModel.findOne({
       // @ts-expect-error
       ra: user?.ra,
+      active: { $ne: false },
       // @ts-expect-error
       $or: [{ teoria: comment?.teacher }, { pratica: comment?.teacher }],
     });

--- a/apps/core/src/models/Student.ts
+++ b/apps/core/src/models/Student.ts
@@ -29,6 +29,7 @@ const coursesSchema = new Schema(
 const studentSchema = new Schema(
   {
     ra: { type: Number, required: true },
+    active: { type: Boolean, default: true },
     login: { type: String, required: true },
     aluno_id: { type: Number, required: false },
     cursos: [coursesSchema],

--- a/apps/core/src/models/User.ts
+++ b/apps/core/src/models/User.ts
@@ -10,7 +10,7 @@ const userSchema = new Schema(
     ra: {
       type: Number,
       unique: true,
-      partialFilterExpression: { ra: { $exists: true } },
+      partialFilterExpression: { ra: { $type: 'number' } },
     },
     email: {
       type: String,
@@ -88,8 +88,50 @@ const userSchema = new Schema(
   }
 );
 
+const userRaHistorySchema = new Schema(
+  {
+    userId: { type: Schema.Types.ObjectId, ref: 'users', required: true },
+    Ra: { type: String, required: true, default: null },
+  },
+  { timestamps: true }
+);
+
+userRaHistorySchema.index({ userId: 1, createdAt: -1 });
+
+export type UserRaHistory = InferSchemaType<typeof userRaHistorySchema>;
+export type UserRaHistoryDocument = ReturnType<
+  (typeof UserRaHistoryModel)['hydrate']
+>;
+
+export const UserRaHistoryModel = model<UserRaHistory>(
+  'user_ras',
+  userRaHistorySchema
+);
+
 type UserBase = InferSchemaType<typeof userSchema>;
 export type User = Omit<UserBase, 'expiresAt'> & { expiresAt: Date | null };
 
 export type UserDocument = ReturnType<(typeof UserModel)['hydrate']>;
 export const UserModel = model<User>('users', userSchema);
+
+export async function ensureUserRaIndex() {
+  const indexes = await UserModel.collection.indexes();
+  const raIndex = indexes.find((index) => index.name === 'ra_1');
+  const acceptsOnlyNumbers =
+    raIndex?.partialFilterExpression?.ra?.$type === 'number';
+
+  if (raIndex && !acceptsOnlyNumbers) {
+    await UserModel.collection.dropIndex('ra_1');
+  }
+
+  if (!raIndex || !acceptsOnlyNumbers) {
+    await UserModel.collection.createIndex(
+      { ra: 1 },
+      {
+        name: 'ra_1',
+        unique: true,
+        partialFilterExpression: { ra: { $type: 'number' } },
+      }
+    );
+  }
+}

--- a/apps/core/src/queue/jobs/user-enrollments.job.ts
+++ b/apps/core/src/queue/jobs/user-enrollments.job.ts
@@ -252,6 +252,7 @@ async function updateHistoryRecords(
     coefficients,
     disciplinas: components,
     graduation: graduation?._id ?? null,
+    active: true,
   };
 
   await Promise.all([
@@ -447,6 +448,7 @@ async function upsertEnrollment(
 ): Promise<void> {
   // @ts-ignore - Mongoose FilterQuery type
   const base: FilterQuery<Enrollment> = {
+    active: { $ne: false },
     ra: enrollmentData.ra,
     season: enrollmentData.season,
   };

--- a/apps/core/src/routes/comments/service.ts
+++ b/apps/core/src/routes/comments/service.ts
@@ -7,6 +7,7 @@ import { type Reaction, ReactionModel } from '@/models/Reaction.js';
 export async function getUserEnrollments(ra: number) {
   const userEnrollments = await EnrollmentModel.find({
     ra,
+    active: { $ne: false },
   }).lean();
 
   return userEnrollments;

--- a/apps/core/src/routes/courseStats/service.ts
+++ b/apps/core/src/routes/courseStats/service.ts
@@ -11,7 +11,10 @@ export async function getCrDistribution(points: number, interval: number) {
 
   const pipeline: any = [
     {
-      $match: { [coefficientsKey]: { $exists: true } },
+      $match: {
+        active: { $ne: false },
+        [coefficientsKey]: { $exists: true },
+      },
     },
     { $project: { value: `$${coefficientsKey}` } },
     {
@@ -34,6 +37,7 @@ export async function getCrDistribution(points: number, interval: number) {
 export async function findLatestHistory(ra: number) {
   const lastHistory = await HistoryModel.findOne({
     ra,
+    active: { $ne: false },
     disciplinas: { $ne: [] },
   }).sort({ updatedAt: -1 });
 
@@ -44,6 +48,7 @@ export async function findOneGraduation(grade: string, curso: string) {
   const graduation = await GraduationHistoryModel.findOne({
     curso,
     grade,
+    active: { $ne: false },
   }).lean<Graduation>();
 
   return graduation;
@@ -52,6 +57,7 @@ export async function findOneGraduation(grade: string, curso: string) {
 export async function getGraduationHistory(ra: number) {
   const history = await GraduationHistoryModel.find({
     ra,
+    active: { $ne: false },
   }).lean();
 
   return history;

--- a/apps/core/src/routes/entities/components/index.ts
+++ b/apps/core/src/routes/entities/components/index.ts
@@ -23,6 +23,7 @@ const validateStudent: preHandlerAsyncHookHandler = async (request, reply) => {
     season: string;
   };
   const student = await StudentModel.findOne({
+    active: { $ne: false },
     season,
     aluno_id: studentId,
   });
@@ -133,6 +134,7 @@ const plugin: FastifyPluginAsyncZodOpenApi = async (app) => {
         {
           $match: {
             season: request.query.season,
+            active: { $ne: false },
             aluno_id: { $in: resolveKicked.map((kicked) => kicked.studentId) },
           },
         },
@@ -148,6 +150,7 @@ const plugin: FastifyPluginAsyncZodOpenApi = async (app) => {
         },
         {
           $match: {
+            active: { $ne: false },
             'cursos.id_curso': {
               $ne: null,
             },

--- a/apps/core/src/routes/entities/enrollments/service.ts
+++ b/apps/core/src/routes/entities/enrollments/service.ts
@@ -17,6 +17,7 @@ type PopulatedFields = {
 export async function listByRa(ra: number) {
   const populatedEnrollments = await EnrollmentModel.find({
     ra,
+    active: { $ne: false },
     conceito: { $in: ['A', 'B', 'C', 'D', 'O', 'F'] },
   })
     .populate<PopulatedFields>(['pratica', 'teoria', 'subject'])
@@ -29,6 +30,7 @@ export async function findOne(id: string, ra: number) {
   const enrollment = await EnrollmentModel.findOne({
     _id: id,
     ra,
+    active: { $ne: false },
   })
     .populate<PopulatedFields>(['pratica', 'teoria', 'subject'])
     .lean();
@@ -49,6 +51,7 @@ export async function listWithComponents(
   const enrollments = await EnrollmentModel.find({
     ra,
     season,
+    active: { $ne: false },
   })
     .populate<{
       pratica: TeacherDocument;

--- a/apps/core/src/routes/entities/students/service.ts
+++ b/apps/core/src/routes/entities/students/service.ts
@@ -38,6 +38,9 @@ export async function getComponentsStudentsStats(
 export async function getAllCourses() {
   const courses = await StudentModel.aggregate([
     {
+      $match: { active: { $ne: false } },
+    },
+    {
       $unwind: '$cursos',
     },
     {
@@ -82,13 +85,18 @@ export async function getStudent(filter: FilterQuery<Student>) {
   const student: Student | null = await StudentModel.findOne({
     ...filter,
     season,
+    active: { $ne: false },
   }).lean();
 
   return student;
 }
 
 export async function getGraduation(ra: number, name: string) {
-  const history = await HistoryModel.findOne({ ra, curso: name }).sort({
+  const history = await HistoryModel.findOne({
+    ra,
+    curso: name,
+    active: { $ne: false },
+  }).sort({
     updatedAt: -1,
   });
 
@@ -130,7 +138,7 @@ export async function createOrInsert({
       ra,
       season,
     },
-    { ra, login, cursos: graduations },
+    { $set: { ra, login, cursos: graduations, active: true } },
     { new: true, upsert: true }
   );
 
@@ -155,6 +163,7 @@ export async function update({
   const student = await StudentModel.findOne({
     ra: resolvedRa,
     season,
+    active: { $ne: false },
   });
 
   if (!student) {
@@ -162,7 +171,7 @@ export async function update({
   }
 
   const historyComponents = await HistoryModel.findOne(
-    { ra: student.ra },
+    { ra: student.ra, active: { $ne: false } },
     { disciplinas: 1, _id: 0 }
   )
     .sort({

--- a/apps/core/src/routes/histories/index.ts
+++ b/apps/core/src/routes/histories/index.ts
@@ -11,7 +11,7 @@ const plugin: FastifyPluginAsyncZodOpenApi = async (app) => {
       _id: string;
       ids: string[];
     }>([
-      { $match: { season } },
+      { $match: { season, active: { $ne: false } } },
       { $unwind: '$cursos' },
       { $match: { 'cursos.id_curso': { $ne: null } } },
       {

--- a/apps/core/src/routes/public/index.ts
+++ b/apps/core/src/routes/public/index.ts
@@ -89,7 +89,7 @@ const plugin: FastifyPluginAsyncZodOpenApi = async (app) => {
     const [users, currentStudents, comments, enrollments, [componentStats]] =
       await Promise.all([
         UserModel.countDocuments({}),
-        StudentModel.countDocuments({}),
+        StudentModel.countDocuments({ active: { $ne: false } }),
         CommentModel.countDocuments({}),
         EnrollmentModel.countDocuments({
           conceito: { $in: ['A', 'B', 'C', 'D', '0', 'F'] },
@@ -236,7 +236,10 @@ const plugin: FastifyPluginAsyncZodOpenApi = async (app) => {
           $exists: true,
         },
       }),
-      currentAlunos: await StudentModel.countDocuments({ season }),
+      currentAlunos: await StudentModel.countDocuments({
+        season,
+        active: { $ne: false },
+      }),
       comments: await CommentModel.countDocuments({}),
       enrollments: await EnrollmentModel.countDocuments({
         conceito: { $in: ['A', 'B', 'C', 'D', 'O', 'F'] },

--- a/apps/core/src/routes/public/service.ts
+++ b/apps/core/src/routes/public/service.ts
@@ -6,6 +6,9 @@ export async function getAllCourses() {
     UFCourseIds: number[];
   }>([
     {
+      $match: { active: { $ne: false } },
+    },
+    {
       $unwind: '$cursos',
     },
     {

--- a/apps/core/src/routes/users/index.ts
+++ b/apps/core/src/routes/users/index.ts
@@ -32,6 +32,7 @@ const plugin: FastifyPluginAsyncZodOpenApi = async (app) => {
     const isUserSynced = await StudentModel.exists({
       ra: user.ra,
       season,
+      active: { $ne: false },
     });
 
     const userInfo = {

--- a/apps/core/src/services/sigaa-student-sync.ts
+++ b/apps/core/src/services/sigaa-student-sync.ts
@@ -1,0 +1,155 @@
+import { UfabcParserConnector } from '@/connectors/ufabc-parser.js';
+import { GraduationHistoryModel } from '@/models/GraduationHistory.js';
+import { HistoryModel } from '@/models/History.js';
+import { EnrollmentModel } from '@/models/Enrollment.js';
+import { StudentModel } from '@/models/Student.js';
+import { UserModel, UserRaHistoryModel } from '@/models/User.js';
+
+const CACHE_TTL = 1000 * 60 * 60 * 24; // 1 day
+
+type SigaaSession = { sessionId: string; viewId: string };
+
+async function deactivateEnrollments(ra: number) {
+    const result = await EnrollmentModel.updateMany(
+        { ra },
+        { $set: { active: false } }
+    );
+
+    return result.modifiedCount;
+}
+
+async function deactivateGrades(ra: number) {
+    await Promise.all([
+        HistoryModel.updateMany({ ra }, { $set: { active: false } }),
+        GraduationHistoryModel.updateMany({ ra }, { $set: { active: false } }),
+    ]);
+}
+
+async function deactivateStudents(ra: number) {
+    await StudentModel.updateMany({ ra }, { $set: { active: false } });
+}
+
+export async function syncStudentFromSigaa(
+    app: any,
+    params: { ra: number; login: string },
+    sigaaSession: SigaaSession,
+    requestId: string
+) {
+    const studentEmailDomain = '@aluno.ufabc.edu.br';
+
+    const connector = new UfabcParserConnector(requestId);
+    const { sessionId, viewId } = sigaaSession;
+
+    const { ra, login } = params;
+
+    const currentRaNumber = ra;
+    const currentRaString = String(ra);
+    const studentEmail = `${login}${studentEmailDomain}`;
+
+    const user = await UserModel.findOne({ email: studentEmail });
+
+    if (!user) {
+        return {
+            status: 'not_found',
+            message: `Usuário não encontrado para o e-mail ${studentEmail}`,
+        } as const;
+    }
+
+    const userRaString = user.ra !== null && user.ra !== undefined ? String(user.ra) : null;
+
+    if (userRaString !== currentRaString) {
+        const userWithSameRa = await UserModel.findOne({
+            ra: currentRaNumber,
+            _id: { $ne: user._id },
+        });
+
+        if (userWithSameRa) {
+            const recentRaChangeWindowDays = 30;
+            const isRecentChange =
+                userWithSameRa.updatedAt !== null &&
+                userWithSameRa.updatedAt !== undefined &&
+                Date.now() - userWithSameRa.updatedAt.getTime() <
+                recentRaChangeWindowDays * 24 * 60 * 60 * 1000;
+
+            if (isRecentChange) {
+                return {
+                    status: 'conflict',
+                    message:
+                        'Este RA está associado a um usuário atualizado recentemente. A reatribuição automática foi bloqueada.',
+                } as const;
+            }
+
+            await UserRaHistoryModel.create({
+                userId: userWithSameRa._id,
+                Ra: currentRaString,
+            });
+
+            await deactivateEnrollments(currentRaNumber);
+            await deactivateGrades(currentRaNumber);
+            await deactivateStudents(currentRaNumber);
+
+            await UserModel.updateOne(
+                { _id: userWithSameRa._id },
+                { $set: { ra: null } }
+            );
+        }
+
+        const previousRa = user.ra !== null && user.ra !== undefined ? String(user.ra) : null;
+
+        if (previousRa !== null) {
+            await UserRaHistoryModel.create({
+                userId: user._id,
+                Ra: previousRa,
+            });
+
+            await deactivateEnrollments(Number(previousRa));
+            await deactivateGrades(Number(previousRa));
+        }
+
+        user.ra = currentRaNumber;
+        await user.save();
+    }
+
+    const cacheKey = `http:students:sigaa:${ra}`;
+
+    let studentSync = await app.db.StudentSync.findOne({ ra: currentRaString });
+    const cached = await app.redis.get(cacheKey);
+
+    if (cached && studentSync?.status === 'completed') {
+        return { status: 'cached', cacheKey } as const;
+    }
+
+    if (!studentSync) {
+        studentSync = await app.db.StudentSync.create({
+            ra: currentRaString,
+            status: 'created',
+            timeline: [
+                {
+                    status: 'created',
+                    metadata: {
+                        login,
+                    },
+                },
+            ],
+        });
+    }
+
+    await connector.syncStudent({
+        sessionId,
+        viewId,
+        requesterKey: app.config.UFABC_PARSER_REQUESTER_KEY,
+    });
+
+    await studentSync.transition('awaiting', {
+        source: 'sigaa',
+        login,
+    });
+    await app.redis.set(cacheKey, login, 'PX', CACHE_TTL);
+
+    return {
+        status: 'success',
+        data: { ra: currentRaString, login },
+    } as const;
+}
+
+export default syncStudentFromSigaa;


### PR DESCRIPTION
# Sincronização do histórico acadêmico via SIGAA

## Resumo

Implementa a sincronização dos dados acadêmicos do aluno a partir do SIGAA, associando as informações ao RA identificado e preservando registros antigos por meio de desativação lógica.

A alteração também prepara a aplicação para lidar com cenários em que um usuário muda de RA ou deixa de possuir um RA ativo, sem excluir permanentemente seus dados acadêmicos anteriores.

## Alterações realizadas

* Adiciona o fluxo `syncStudentFromSigaa`.
* Atualiza o vínculo do `User` com o RA obtido do SIGAA.
* Registra alterações de RA no histórico do usuário.
* Adiciona o campo `active` aos modelos relacionados a:

  * aluno;
  * histórico acadêmico;
  * matrículas.
* Desativa logicamente registros associados a um RA que passou a pertencer a outro usuário.
* Atualiza consultas para considerar apenas registros ativos.
* Ajusta a sincronização de estudantes, históricos e matrículas para preservar registros anteriores sem apresentá-los como dados atualmente ativos.

## Comportamento esperado

Quando ocorre uma alteração de RA:

1. O vínculo atual do usuário é atualizado.
2. O RA anterior é preservado no histórico do usuário.
3. Os registros relacionados ao RA anterior permanecem armazenados.
4. Esses registros são marcados como inativos quando não devem mais representar o estado atual.
5. As consultas padrão retornam apenas registros ativos.

## Testes

Foram considerados os seguintes cenários:

* Sincronização de usuário sem RA previamente associado.
* Sincronização de usuário cujo RA permanece o mesmo.
* Alteração do RA associado ao usuário.
* Registro do RA anterior no histórico do usuário.
* Desativação lógica dos dados relacionados ao RA anterior quando necessário.
* Manutenção dos registros antigos no banco após a desativação.
* Sincronização de histórico acadêmico e matrículas vinculados ao RA atual.
* Validação de que consultas padrão retornam apenas registros com `active: true`.
* Validação de que registros inativos não são reativados indevidamente durante novas sincronizações.

## Próximos passos

* Permitir que usuários que mudaram de RA continuem visualizando o histórico associado aos próprios RAs anteriores.
* Permitir que usuários que perderam o RA e tiveram seus registros desativados continuem acessando o próprio histórico acadêmico.
* Ajustar a resolução do histórico para considerar identidades anteriores do usuário sem reativar registros que devem permanecer inativos.

## Observações

A implementação atual utiliza **soft delete/desativação lógica**.

Nenhum registro acadêmico antigo é removido permanentemente do banco de dados. Os dados permanecem armazenados e são diferenciados por meio do campo `active`.
